### PR TITLE
add SetMode (CSI Ps h, CSI ? Ps h)

### DIFF
--- a/examples/ansilog/main.go
+++ b/examples/ansilog/main.go
@@ -194,6 +194,10 @@ func (*handler) SetKeyboardMode(mode ansicode.KeyboardMode, behavior ansicode.Ke
 	fmt.Printf("SetKeyboardMode %v %v\n", mode, behavior)
 }
 
+func (*handler) SetMode(mode ansicode.TerminalMode) {
+	fmt.Printf("SetMode %v\n", mode)
+}
+
 func (*handler) SetModifyOtherKeys(modify ansicode.ModifyOtherKeys) {
 	fmt.Printf("SetModifyOtherKeys %v\n", modify)
 }

--- a/handler.go
+++ b/handler.go
@@ -159,6 +159,9 @@ type Handler interface {
 	// SetKeypadApplicationMode sets keypad to applications mode.
 	SetKeypadApplicationMode()
 
+	// SetMode sets the given mode.
+	SetMode(mode TerminalMode)
+
 	// SetModifyOtherKeys sets the modify other keys mode. (XTERM)
 	SetModifyOtherKeys(modify ModifyOtherKeys)
 

--- a/handler_test.go
+++ b/handler_test.go
@@ -239,6 +239,11 @@ func (h *handlerMock) SetKeyboardMode(mode KeyboardMode, behavior KeyboardModeBe
 	h.args = append(h.args, behavior)
 }
 
+func (h *handlerMock) SetMode(mode TerminalMode) {
+	h.called = append(h.called, "SetMode")
+	h.args = append(h.args, mode)
+}
+
 func (h *handlerMock) SetModifyOtherKeys(modify ModifyOtherKeys) {
 	h.called = append(h.called, "SetModifyOtherKeys")
 	h.args = append(h.args, modify)

--- a/performer_csi.go
+++ b/performer_csi.go
@@ -271,6 +271,26 @@ func (p *Performer) CsiDispatch(params [][]uint16, intermediates []byte, ignore 
 		n := paramsIter.GetNextOrDefault(1)
 		p.handler.InsertBlankLines(int(n))
 
+	case action == 'h' && len(intermediates) == 0:
+		for _, param := range flatParams {
+			mode, ok := terminalMode(param, false)
+			if ok {
+				p.handler.SetMode(mode)
+			} else {
+				log.Debugf("Unhandled CSI params=%v intermediates=%v ignore=%v action=%v", params, intermediates, ignore, action)
+			}
+		}
+
+	case action == 'h' && len(intermediates) > 0 && intermediates[0] == '?':
+		for _, param := range flatParams {
+			mode, ok := terminalMode(param, true)
+			if ok {
+				p.handler.SetMode(mode)
+			} else {
+				log.Debugf("Unhandled CSI params=%v intermediates=%v ignore=%v action=%v", params, intermediates, ignore, action)
+			}
+		}
+
 	case action == 'l' && len(intermediates) == 0:
 		for _, param := range flatParams {
 			mode, ok := terminalMode(param, false)

--- a/performer_csi_test.go
+++ b/performer_csi_test.go
@@ -95,6 +95,28 @@ func TestPerformer_CsiDispatch(t *testing.T) {
 		// CSI Ps L
 		{name: "CSI 3 L", args: args{params: [][]uint16{{3}}, action: 'L'}, want: want{mock: m("InsertBlankLines", 3)}},
 
+		// CSI Ps h
+		{name: "CSI 4 h", args: args{params: [][]uint16{{4}}, action: 'h'}, want: want{mock: m("SetMode", TerminalModeInsert)}},
+		{name: "CSI 20 h", args: args{params: [][]uint16{{20}}, action: 'h'}, want: want{mock: m("SetMode", TerminalModeLineFeedNewLine)}},
+
+		// CSI ? Ps h
+		{name: "CSI ? 1 h", args: args{params: [][]uint16{{1}}, intermediates: []byte{'?'}, action: 'h'}, want: want{mock: m("SetMode", TerminalModeCursorKeys)}},
+		{name: "CSI ? 3 h", args: args{params: [][]uint16{{3}}, intermediates: []byte{'?'}, action: 'h'}, want: want{mock: m("SetMode", TerminalModeColumnMode)}},
+		{name: "CSI ? 6 h", args: args{params: [][]uint16{{6}}, intermediates: []byte{'?'}, action: 'h'}, want: want{mock: m("SetMode", TerminalModeOrigin)}},
+		{name: "CSI ? 7 h", args: args{params: [][]uint16{{7}}, intermediates: []byte{'?'}, action: 'h'}, want: want{mock: m("SetMode", TerminalModeLineWrap)}},
+		{name: "CSI ? 12 h", args: args{params: [][]uint16{{12}}, intermediates: []byte{'?'}, action: 'h'}, want: want{mock: m("SetMode", TerminalModeBlinkingCursor)}},
+		{name: "CSI ? 25 h", args: args{params: [][]uint16{{25}}, intermediates: []byte{'?'}, action: 'h'}, want: want{mock: m("SetMode", TerminalModeShowCursor)}},
+		{name: "CSI ? 1000 h", args: args{params: [][]uint16{{1000}}, intermediates: []byte{'?'}, action: 'h'}, want: want{mock: m("SetMode", TerminalModeReportMouseClicks)}},
+		{name: "CSI ? 1002 h", args: args{params: [][]uint16{{1002}}, intermediates: []byte{'?'}, action: 'h'}, want: want{mock: m("SetMode", TerminalModeReportCellMouseMotion)}},
+		{name: "CSI ? 1003 h", args: args{params: [][]uint16{{1003}}, intermediates: []byte{'?'}, action: 'h'}, want: want{mock: m("SetMode", TerminalModeReportAllMouseMotion)}},
+		{name: "CSI ? 1004 h", args: args{params: [][]uint16{{1004}}, intermediates: []byte{'?'}, action: 'h'}, want: want{mock: m("SetMode", TerminalModeReportFocusInOut)}},
+		{name: "CSI ? 1005 h", args: args{params: [][]uint16{{1005}}, intermediates: []byte{'?'}, action: 'h'}, want: want{mock: m("SetMode", TerminalModeUTF8Mouse)}},
+		{name: "CSI ? 1006 h", args: args{params: [][]uint16{{1006}}, intermediates: []byte{'?'}, action: 'h'}, want: want{mock: m("SetMode", TerminalModeSGRMouse)}},
+		{name: "CSI ? 1007 h", args: args{params: [][]uint16{{1007}}, intermediates: []byte{'?'}, action: 'h'}, want: want{mock: m("SetMode", TerminalModeAlternateScroll)}},
+		{name: "CSI ? 1042 h", args: args{params: [][]uint16{{1042}}, intermediates: []byte{'?'}, action: 'h'}, want: want{mock: m("SetMode", TerminalModeUrgencyHints)}},
+		{name: "CSI ? 1049 h", args: args{params: [][]uint16{{1049}}, intermediates: []byte{'?'}, action: 'h'}, want: want{mock: m("SetMode", TerminalModeSwapScreenAndSetRestoreCursor)}},
+		{name: "CSI ? 2004 h", args: args{params: [][]uint16{{2004}}, intermediates: []byte{'?'}, action: 'h'}, want: want{mock: m("SetMode", TerminalModeBracketedPaste)}},
+
 		// CSI Ps l
 		{name: "CSI 4 l", args: args{params: [][]uint16{{4}}, action: 'l'}, want: want{mock: m("UnsetMode", TerminalModeInsert)}},
 		{name: "CSI 20 l", args: args{params: [][]uint16{{20}}, action: 'l'}, want: want{mock: m("UnsetMode", TerminalModeLineFeedNewLine)}},


### PR DESCRIPTION
Hi! Thanks a ton for making this package, I'm trying it out for [midterm](https://github.com/vito/midterm) and it's been a breeze so far. Really happy replacing my janky parser, and to no longer have to scour the internet to figure out all these ancient escape sequences. 😄

I have an "interesting" test suite that runs against recorded `htop` and `vim` sessions and it's shaking out a few missing things here and there. In the case for this PR, I noticed it's possible to unset a mode, but not set one. Pattern-matched my way to a fix. 🙏 