### PR TITLE
fix underline parsing as 'cancel underline'

### DIFF
--- a/performer_csi.go
+++ b/performer_csi.go
@@ -322,7 +322,12 @@ func (p *Performer) CsiDispatch(params [][]uint16, intermediates []byte, ignore 
 				p.handler.SetTerminalCharAttribute(attr(CharAttributeItalic))
 
 			case 4:
-				switch paramsIter.GetNextOrDefault(0) {
+				ps, ok := paramsIter.GetNext()
+				if !ok {
+					p.handler.SetTerminalCharAttribute(attr(CharAttributeUnderline))
+					break
+				}
+				switch ps {
 				case 0:
 					p.handler.SetTerminalCharAttribute(attr(CharAttributeCancelUnderline))
 

--- a/performer_csi_test.go
+++ b/performer_csi_test.go
@@ -125,6 +125,7 @@ func TestPerformer_CsiDispatch(t *testing.T) {
 		{name: "CSI 1 m", args: args{params: [][]uint16{{1}}, action: 'm'}, want: want{mock: m("SetTerminalCharAttribute", attr(CharAttributeBold))}},
 		{name: "CSI 2 m", args: args{params: [][]uint16{{2}}, action: 'm'}, want: want{mock: m("SetTerminalCharAttribute", attr(CharAttributeDim))}},
 		{name: "CSI 3 m", args: args{params: [][]uint16{{3}}, action: 'm'}, want: want{mock: m("SetTerminalCharAttribute", attr(CharAttributeItalic))}},
+		{name: "CSI 4 m", args: args{params: [][]uint16{{4}}, action: 'm'}, want: want{mock: m("SetTerminalCharAttribute", attr(CharAttributeUnderline))}},
 		{name: "CSI 4 ; 0 m", args: args{params: [][]uint16{{4}, {0}}, action: 'm'}, want: want{mock: m("SetTerminalCharAttribute", attr(CharAttributeCancelUnderline))}},
 		{name: "CSI 4 ; 2 m", args: args{params: [][]uint16{{4}, {2}}, action: 'm'}, want: want{mock: m("SetTerminalCharAttribute", attr(CharAttributeDoubleUnderline))}},
 		{name: "CSI 4 ; 3 m", args: args{params: [][]uint16{{4}, {3}}, action: 'm'}, want: want{mock: m("SetTerminalCharAttribute", attr(CharAttributeCurlyUnderline))}},


### PR DESCRIPTION
Noticed `\e[4m` was being treated the same as `\e[4:0m` (reset underline) so it wasn't actually possible to set an underline.